### PR TITLE
Support pagination in notes request

### DIFF
--- a/src/js/popup/actions/spentTime.js
+++ b/src/js/popup/actions/spentTime.js
@@ -11,9 +11,17 @@ export function onNewMergeRequest(selectedProjectId, selectedMergeRequestId) {
     };
 
     dispatch({ type: ON_NOTES_PENDING, data: requestSettings });
+
+    const onNotesLoad = (result) => {
+      dispatch({ type: ON_NOTES_LOAD, data: { notes: result.notes, isFinal: !result.nextRequest, requestSettings } })
+      if (result.nextRequest) {
+        return result.nextRequest.then(onNotesLoad);
+      }
+      return Promise.resolve();
+    };
+
     const state = getState();
-    return requestNotes(state.settings.hostname, state.settings.token, selectedProjectId, selectedMergeRequestId)
-      .then((notes) => dispatch({ type: ON_NOTES_LOAD, data: { notes, requestSettings } }));
+    return requestNotes(state.settings.hostname, state.settings.token, selectedProjectId, selectedMergeRequestId).then(onNotesLoad);
   }
 }
 

--- a/src/js/popup/reducers/spentTime.js
+++ b/src/js/popup/reducers/spentTime.js
@@ -9,9 +9,19 @@ const initialState = {
 function addSpentTimeIfPossible(state) {
   if (!state.notes || state.userId == -1) return state;
 
+  const time = calculateSpentTime(state.notes, state.userId) + state.time;
+
+  if (state.isComplete) {
+    return {
+      userId: state.userId,
+      time
+    };
+  }
   return {
     userId: state.userId,
-    time: calculateSpentTime(state.notes, state.userId)
+    notes: [],
+    time,
+    pendingRequest: state.pendingRequest,
   };
 }
 
@@ -21,11 +31,15 @@ export function spentTime(state = initialState, action) {
       return addSpentTimeIfPossible({ ...state, userId: action.data });
     case ON_NOTES_LOAD:
       if (action.data.requestSettings == state.pendingRequest) {
-        return addSpentTimeIfPossible({ ...state, notes: action.data.notes });
+        return addSpentTimeIfPossible({
+          ...state,
+          notes: [ ...state.notes, ...action.data.notes ],
+          isComplete: action.data.isFinal,
+        });
       }
       return state;
     case ON_NOTES_PENDING:
-      return { ...state, time: 0, pendingRequest: action.data };
+      return { ...state, notes: [], time: 0, pendingRequest: action.data };
     case STOP_TIMER:
       return {...state, time: state.time + action.data.spentTime };
   }

--- a/src/js/popup/services/gitlabParser.js
+++ b/src/js/popup/services/gitlabParser.js
@@ -3,6 +3,9 @@ function sum(x, y) {
 }
 
 function parseTimeElement(element) {
+  if (element.endsWith('mo'))return parseInt(element) * 60 * 60 * 8 * 5 * 4;
+  if (element.endsWith('w')) return parseInt(element) * 60 * 60 * 8 * 5;
+  if (element.endsWith('d')) return parseInt(element) * 60 * 60 * 8;
   if (element.endsWith('h')) return parseInt(element) * 60 * 60;
   if (element.endsWith('m')) return parseInt(element) * 60;
   if (element.endsWith('s')) return parseInt(element);


### PR DESCRIPTION
Notes can be received by pages. So, we should parse link header and get next page when it exists.
This way we will request all pages incrementally and get all notes.
Also months, weeks and days are supported in parsing.
Also number of notes per page is increased to get spent time quickly.