### PR TITLE
Fix warning about Function/eval usage

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ if (fileSystem.existsSync(secretsPath)) {
 }
 
 var options = {
+  node: false,
   mode: "production",
   entry: {
     popup: path.join(__dirname, "src", "js", "popup.js"),


### PR DESCRIPTION
Warning was caused by code in webpack. See for details:
https://stackoverflow.com/questions/48695579/how-to-remove-eval-and-function-constructor-from-webpack-build-to-avoid-csp-issu