### PR TITLE
Revert html prettier formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "node utils/build.js",
     "start": "node utils/webserver.js",
-    "format": "prettier --write 'src/css/*.css' 'src/**/*.js' 'src/**/*.html'",
-    "test": "jshint src & prettier --check 'src/css/*.css' 'src/**/*.js' 'src/**/*.html'"
+    "format": "prettier --write 'src/css/*.css' 'src/**/*.js'",
+    "test": "jshint src & prettier --check 'src/css/*.css' 'src/**/*.js'"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^1.0.0",

--- a/src/options.html
+++ b/src/options.html
@@ -13,11 +13,10 @@
           id="hostname"
           class="form-control"
           aria-describedby="hostnameHelp"
-          placeholder="Enter GitLab host"
-        />
-        <small id="hostnameHelp" class="form-text text-muted"
-          >e.g. https://gitlab.com</small
-        >
+          placeholder="Enter GitLab host" />
+        <small id="hostnameHelp" class="form-text text-muted">
+          e.g. https://gitlab.com
+        </small>
       </div>
       <div class="form-group">
         <label for="token">GitLab token</label>
@@ -26,11 +25,10 @@
           id="token"
           class="form-control"
           aria-describedby="tokenHelp"
-          placeholder="Enter GitLab token"
-        />
-        <small id="tokenHelp" class="form-text text-muted"
-          >Get it from "Settings" -> "Access Tokens" page</small
-        >
+          placeholder="Enter GitLab token" />
+        <small id="tokenHelp" class="form-text text-muted">
+          Get it from "Settings" -> "Access Tokens" page
+        </small>
       </div>
       <div>
         <button type="submit" class="btn btn-primary">Save</button>

--- a/src/popup.html
+++ b/src/popup.html
@@ -7,8 +7,7 @@
   <body>
     <div class="card">
       <div
-        class="card-header bg-dark text-white py-1 d-flex align-items-center"
-      >
+        class="card-header bg-dark text-white py-1 d-flex align-items-center">
         <div class="container">
           <div class="row">
             <div class="col align-self-center">
@@ -23,13 +22,12 @@
             <div class="col-auto">
               <div
                 class="ml-auto text-right timer-counter timer-counter-total"
-                id="timerTotal"
-              >
+                id="timerTotal">
                 00:00:00
               </div>
-              <small id="timerTotalHelp" class="form-text text-right"
-                >total</small
-              >
+              <small id="timerTotalHelp" class="form-text text-right">
+                total
+              </small>
             </div>
           </div>
         </div>
@@ -43,11 +41,10 @@
                 class="form-control"
                 id="projectId"
                 aria-describedby="projectIdHelp"
-                placeholder="Project"
-              />
-              <small id="projectIdHelp" class="form-text text-muted"
-                >Project name</small
-              >
+                placeholder="Project" />
+              <small id="projectIdHelp" class="form-text text-muted">
+                Project name
+              </small>
             </div>
             <div class="col">
               <input
@@ -55,11 +52,10 @@
                 class="form-control"
                 id="mergeRequestId"
                 aria-describedby="mergeRequestIdHelp"
-                placeholder="Merge request"
-              />
-              <small id="mergeRequestIdHelp" class="form-text text-muted"
-                >Merge request Id</small
-              >
+                placeholder="Merge request" />
+              <small id="mergeRequestIdHelp" class="form-text text-muted">
+                Merge request Id
+              </small>
             </div>
             <div class="col-auto">
               <button id="timerToggler" class="btn align-top border-0 mt-1">


### PR DESCRIPTION
See https://github.com/prettier/prettier/issues/5377
We decided to disable prettier for html for now and manually format it
Note, that line lengths are still less than 80 characters