### PR TITLE
Fix url parsing for new GitLab version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-easy-time-tracking",
-  "version": "0.2.1",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -88,7 +88,9 @@ class Popup {
     let elems = path.split("/");
     const projectId = elems.length > 2 ? elems[1] + "/" + elems[2] : "";
     const mergeRequestId =
-      elems.length > 4 && elems[3] == "merge_requests" ? elems[4] : "";
+      elems[elems.length - 2] == "merge_requests"
+        ? elems[elems.length - 1]
+        : "";
     return [projectId, mergeRequestId];
   }
 


### PR DESCRIPTION
Example: https://gitlab.com/acubesat/obc/ecss-services/-/merge_requests/17